### PR TITLE
Add globally configurable properties_seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*Hacky fork that adds a global configurable properties_seperator that overrides the default merge_properties underscore seperator.*
+
 `MetaEvents` is a Ruby gem that sits on top of a user-centric analytics system like
 [Mixpanel](https://www.mixpanel.com/) and provides structure, documentation, and a historical record to events,
 and a powerful properties system that makes it easy to pass large numbers of consistent properties with your events.

--- a/lib/meta_events/definition/definition_set.rb
+++ b/lib/meta_events/definition/definition_set.rb
@@ -48,10 +48,14 @@ module MetaEvents
       def initialize(options = { }, &block)
         @global_events_prefix = nil
         @versions = { }
+        @properties_seperator = '_'
 
         options.assert_valid_keys(:global_events_prefix, :definition_text)
+        options.assert_valid_keys(:global_events_prefix, :definition_text, :properties_seperator)
 
         global_events_prefix options[:global_events_prefix] if options[:global_events_prefix]
+
+        properties_seperator options[:properties_seperator] if options[:properties_seperator]
 
         @source_description = "passed-in data/block"
 
@@ -77,6 +81,14 @@ module MetaEvents
           @global_events_prefix = prefix.to_s
         else
           @global_events_prefix
+        end
+      end
+
+      def properties_seperator(seperator = nil)
+        if seperator
+          @properties_seperator = seperator
+        else
+          @properties_seperator
         end
       end
 


### PR DESCRIPTION
Although i personally prefer the default underscored properties our client prefers translated properties in Mixpanel. In order to write properties in their natural language i added the option for properties names seperated by spaces instead of underscores. 

Solution is pretty hacky and global :confused: 
