### PR TITLE
Fix for time zone changing on time objects passed to Tracker#event!

### DIFF
--- a/lib/meta_events/tracker.rb
+++ b/lib/meta_events/tracker.rb
@@ -527,7 +527,7 @@ module MetaEvents
         when Numeric then value
         when String then value.strip
         when Symbol then value.to_s.strip
-        when Time then value.utc.strftime("%Y-%m-%dT%H:%M:%S")
+        when Time then value.getutc.strftime("%Y-%m-%dT%H:%M:%S")
         when Array then
           out = value.map { |e| normalize_scalar_property_value(e) }
           out = :invalid_property_value if out.detect { |e| e == :invalid_property_value }

--- a/spec/meta_events/tracker_spec.rb
+++ b/spec/meta_events/tracker_spec.rb
@@ -584,5 +584,37 @@ EOS
         expect(klass.normalize_scalar_property_value(input)).to eq(output)
       end
     end
+
+    it "should not modify passed values" do
+      t = Time.parse("2008-09-04 3:46:12 PM -08:00")
+      [
+        nil,
+        true,
+        false,
+        3,
+        42.5e+17,
+        3.months,
+        :foobar,
+        :' FooBar  ',
+        ' FooBar  ',
+        t,
+        [ "foo", :bar, 123, -9.45e+17, t, false, nil, true, "  BoNk " ],
+        /foobar/,
+        Object.new
+      ].each do |input|
+        expect { klass.normalize_scalar_property_value(input) }.to_not change { input }
+      end
+
+      nan = (0.0 / 0.0)
+      expect { klass.normalize_scalar_property_value(nan) }.to_not change { nan.nan? }
+
+      infinity = (1.0 / 0.0)
+      expect { klass.normalize_scalar_property_value(infinity) }.to_not change { infinity.infinite? }
+
+      neg_infinity = -(1.0 / 0.0)
+      expect { klass.normalize_scalar_property_value(neg_infinity) }.to_not change { neg_infinity.infinite? }
+
+      expect { klass.normalize_scalar_property_value(t) }.to_not change { t.zone }
+    end
   end
 end


### PR DESCRIPTION
Time objects passed as property values have their time zone changed to UTC. Fix uses Time#getutc instead of Time#utc in Tracker::normalize_scalar_property_value. Time#utc modifies the receiver (see: http://ruby-doc.org/core-2.1.2/Time.html#method-i-utc).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/swiftype/meta_events/10)

<!-- Reviewable:end -->
