### PR TITLE
Adding conditional require for spring/watcher

### DIFF
--- a/lib/meta_events/railtie.rb
+++ b/lib/meta_events/railtie.rb
@@ -1,3 +1,4 @@
+require 'spring/watcher' if defined?(::Spring)
 module MetaEvents
   class Railtie < Rails::Railtie
     def say(x)


### PR DESCRIPTION
Fixing the `undefined method`watch' for Spring:Module` error.
