### PR TITLE
Fixing deprecation warnings

### DIFF
--- a/spec/meta_events/definition/version_spec.rb
+++ b/spec/meta_events/definition/version_spec.rb
@@ -58,7 +58,9 @@ describe ::MetaEvents::Definition::Version do
 
     it "should be able to create a new category, and retrieve it" do
       blk = lambda { :whatever }
-      expect(::MetaEvents::Definition::Category).to receive(:new).once.with(instance, ' FooBar ', :bar => :baz, &blk).and_return(category)
+      expect(::MetaEvents::Definition::Category).to receive(:new).once.with(instance, ' FooBar ', :bar => :baz) do |*args, &block|
+        expect(block).to eq(blk)
+      end.and_return(category)
       instance.category(' FooBar ', :bar => :baz, &blk)
 
       expect(instance.category_named(:quux)).to be(category)

--- a/spec/meta_events/tracker_spec.rb
+++ b/spec/meta_events/tracker_spec.rb
@@ -503,7 +503,7 @@ EOS
     it "should include a distinct ID of nil if there is none" do
       i = new_instance(nil, nil, :definitions => definition_set, :version => 1)
       h = i.effective_properties(:foo, :bar)
-      expect(h.has_key?(:distinct_id)).to be_true
+      expect(h.has_key?(:distinct_id)).to be_truthy
       expect(h[:distinct_id]).to be_nil
     end
 


### PR DESCRIPTION
Fixing 2 deprecation warnings when running specs and a test that was still passing even if no block was passed with category method.