### PR TITLE
Changing Time.now calls to Time.current

### DIFF
--- a/lib/meta_events/tracker.rb
+++ b/lib/meta_events/tracker.rb
@@ -157,7 +157,7 @@ module MetaEvents
   #       ...
   #       def to_event_properties
   #         {
-  #            :age => ((Time.now - date_of_birth) / 1.year).floor,
+  #            :age => ((Time.current - date_of_birth) / 1.year).floor,
   #            :payment_level => payment_level,
   #            :city => home_city
   #            ...
@@ -384,7 +384,7 @@ module MetaEvents
     # class.
     def event!(category_name, event_name, additional_properties = { })
       event_data = effective_properties(category_name, event_name, additional_properties)
-      event_data[:properties] = { 'time' => Time.now.to_i }.merge(event_data[:properties])
+      event_data[:properties] = { 'time' => Time.current.to_i }.merge(event_data[:properties])
 
       self.event_receivers.each do |receiver|
         receiver.track(event_data[:distinct_id], event_data[:external_name], event_data[:properties])

--- a/spec/meta_events/tracker_spec.rb
+++ b/spec/meta_events/tracker_spec.rb
@@ -178,10 +178,10 @@ EOS
 
     describe "time support" do
       it "should add the time to the event" do
-        start_time = Time.now.to_i
+        start_time = Time.current.to_i
         i = new_instance(@distinct_id, nil, :definitions => definition_set, :version => 1)
         i.event!(:foo, :bar, { })
-        end_time = Time.now.to_i
+        end_time = Time.current.to_i
         actual_properties = expect_event('xy1_foo_bar', { })
         time = actual_properties['time']
         expect(time).to be >= start_time
@@ -189,14 +189,14 @@ EOS
       end
 
       it "should allow overriding the time" do
-        actual_time = Time.now.to_i - 500
+        actual_time = Time.current.to_i - 500
         i = new_instance(@distinct_id, nil, :definitions => definition_set, :version => 1)
         i.event!(:foo, :bar, { :time => actual_time })
         expect_event('xy1_foo_bar', { 'time' => actual_time })
       end
 
       it "should allow omitting the time" do
-        actual_time = Time.now.to_i - 500
+        actual_time = Time.current.to_i - 500
         i = new_instance(@distinct_id, nil, :definitions => definition_set, :version => 1)
         i.event!(:foo, :bar, { :time => nil })
         expect_event('xy1_foo_bar', { 'time' => nil })


### PR DESCRIPTION
Time.now returns system time and ignores the project's configured time zone.