### PR TITLE
Gemspec: Support rails 5

### DIFF
--- a/meta_events.gemspec
+++ b/meta_events.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "json", "~> 1.0"
-  spec.add_dependency "activesupport", ">= 3.0", "<= 4.99.99"
+  spec.add_dependency "activesupport", ">= 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Hi @look 

Removed activesupport dependency constraint to make the gem work with rails 5 alpha. 

Please review and merge. 

Thanks